### PR TITLE
Add heap usage profiler to the project.

### DIFF
--- a/Allocator.h
+++ b/Allocator.h
@@ -45,14 +45,6 @@
 
 #include "GCUtil.h"
 
-#ifdef PROFILE_MASSIF
-#include <unordered_map>
-#include <vector>
-
-extern std::unordered_map<void*, void*> g_addressTable;
-extern std::vector<void*> g_freeList;
-#endif
-
 namespace GCUtil {
 
 template <class GC_Tp>

--- a/GCUtil.h
+++ b/GCUtil.h
@@ -25,16 +25,12 @@
     } while (0)
 #endif
 
-//#define PROFILE_MASSIF
-#ifdef PROFILE_MASSIF
-
-void registerGCAddress(void* address, size_t siz);
-void unregisterGCAddress(void* address);
-
+#ifdef ESCARGOT_MEM_STATS
 void* GC_malloc_hook(size_t siz);
 void* GC_malloc_uncollectable_hook(size_t siz);
 void* GC_malloc_atomic_hook(size_t siz);
 void* GC_malloc_atomic_uncollectable_hook(size_t siz);
+void* GC_malloc_explicitly_typed_hook(size_t siz, GC_descr d);
 void* GC_generic_malloc_hook(size_t siz, int kind);
 void* GC_malloc_stubborn_hook(size_t siz);
 void* GC_strdup_hook(const char* str);
@@ -42,8 +38,13 @@ void* GC_strndup_hook(const char* str, size_t siz);
 void* GC_realloc_hook(void* address, size_t siz);
 void GC_free_hook(void* address);
 
+void GC_register_finalizer_no_order_hook(void* obj, GC_finalization_proc fn,
+                                         void* cd, GC_finalization_proc *ofn,
+                                         void** ocd);
+void GC_print_heap_usage();
+
 #undef GC_MALLOC_EXPLICITLY_TYPED
-#define GC_MALLOC_EXPLICITLY_TYPED(bytes, d) GC_MALLOC(bytes)
+#define GC_MALLOC_EXPLICITLY_TYPED(bytes, d) GC_malloc_explicitly_typed_hook(bytes, d)
 
 #undef GC_MALLOC
 #define GC_MALLOC(X) GC_malloc_hook(X)
@@ -56,6 +57,9 @@ void GC_free_hook(void* address);
 
 #undef GC_MALLOC_ATOMIC_UNCOLLECTABLE
 #define GC_MALLOC_ATOMIC_UNCOLLECTABLE(sz) GC_malloc_atomic_uncollectable_hook(sz)
+
+#undef GC_MALLOC_EXPLICITLY_TYPED
+#define GC_MALLOC_EXPLICITLY_TYPED(bytes, d) GC_malloc_explicitly_typed_hook(bytes, d)
 
 #undef GC_GENERIC_MALLOC
 #define GC_GENERIC_MALLOC(siz, kind) GC_generic_malloc_hook(siz, kind)
@@ -76,7 +80,7 @@ void GC_free_hook(void* address);
 #define GC_FREE(X) GC_free_hook(X)
 
 #undef GC_REGISTER_FINALIZER_NO_ORDER
-#define GC_REGISTER_FINALIZER_NO_ORDER(p, f, d, of, od) GC_register_finalizer_no_order(p, f, d, of, od)
+#define GC_REGISTER_FINALIZER_NO_ORDER(p, f, d, of, od) GC_register_finalizer_no_order_hook(p, f, d, of, od);
 
 #endif
 


### PR DESCRIPTION
I've created a memory usage tracker feature based on PROFILE_MASSIF. By tracking the allcoations and deallocations, the following information can be computed:

  * Total allocation
  * Peak allocation
  * Total waste
  * Peak waste
  * Allcoation count
  * Free count

All the GC allocations (`GC_MALLOC`, `GC_REALLOC`, `GC_STRDUP`, ...) are hooked in order to save the GC pointers and their sizes. The deallocation tracking is based on GC finalizer callbacks: callbacks can be bound to the memory address that are executed before the GC clears the memory area.

There are cases (e.g. in [BytecodeBlock.h_1711](https://github.com/pando-project/escargot/blob/master/src/interpreter/ByteCode.h#L1711)) when Escargot wants to register a callback for an address. Since BDWGC supports only one callback per object, it's needed to manually save the user defined callbacks to the allocated pointer.

I've added Valgrind support for this feature to be able to use more detailed profilers with the project.